### PR TITLE
fix expanded div reference when validating Outside div click

### DIFF
--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -13,7 +13,8 @@ const Menu = () => {
 
   const handleClickOutside = (event: MouseEvent) => {
     const target = event.target as HTMLElement;
-    if (!target.closest('.expanded-btn-div')) {
+
+    if (target.closest('.expanded-btn-div') === null) {
       setIsExpanded(false);
     }
   };
@@ -53,7 +54,7 @@ const Menu = () => {
       { isAuthenticated ? (
           <>
             <SeeMoreBtn theme={defaultTheme} onClick={handleProfileClick} />
-            <ExpandedBtnDiv hide={!isExpanded}>
+            <ExpandedBtnDiv hide={!isExpanded} className='expanded-btn-div'>
               <ExpandedLinks onClick={() => navigate('/')}>Perfil</ExpandedLinks>
               {/* <ExpandedLinks onClick={() => navigate('/')}>Settings</ExpandedLinks> */}
               <ExpandedLinks onClick={handleLogout}>Sair</ExpandedLinks>


### PR DESCRIPTION
Este PR está corrigindo o toggle do menu.

Antes, ao clicar para selecionar 'Sair', a ação não ocorria pelo fechamento inesperado da div devido a uma validação incorreta.

Tal validação seria para que o Expanded Menu fechasse ao clicar fora dele, mas a referência da classe para o sistema saber onde seria 'clicar fora' estava incorreta.